### PR TITLE
Фикс атмоса

### DIFF
--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -218,6 +218,14 @@
 		if(RCON_YES)
 			remote_control = 1
 
+	//Костыль на костыле с целью фикса атмоса
+	if ((environment.gas[GAS_NITROGEN]*R_IDEAL_GAS_EQUATION*environment.temperature/environment.volume) > 79.2)
+		for(var/device_id in alarm_area.air_scrub_names)
+			send_signal(device_id, list("n2_scrub" = 1))
+	else 
+		for(var/device_id in alarm_area.air_scrub_names)
+			send_signal(device_id, list("n2_scrub" = 0))
+
 	return
 
 /obj/machinery/alarm/proc/handle_heating_cooling(var/datum/gas_mixture/environment)


### PR DESCRIPTION
## Вставление костыля в лопасти вентиляторов
Исправляет ишью #10

Заставляет скрабберы высасывать лишний азот из помещения, тем самым устраняя проблему переполнения помещения азотом. Способ костыльный, но работать должно

Ченджлог
---
Фикс переполнения помещений азотом